### PR TITLE
Allineamento orizzontale del Blocco Contatti

### DIFF
--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/Block/ViewBlock.jsx
@@ -20,7 +20,7 @@ import { checkRedraftHasContent } from 'design-comuni-plone-theme/helpers';
 const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
   return (
     <Card
-      className="card-bg rounded subblock-view"
+      className="card-bg rounded subblock-view "
       noWrapper={false}
       space
       tag="div"

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/Edit.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/Edit.jsx
@@ -106,7 +106,7 @@ class Edit extends SubblocksEdit {
             </div>
 
             <SubblocksWrapper node={this.node}>
-              <Row>
+              <Row className="justify-content-center">
                 {this.state.subblocks.map((subblock, subindex) => (
                   <Col lg="4" key={subblock.id}>
                     <EditBlock
@@ -120,7 +120,7 @@ class Edit extends SubblocksEdit {
                 ))}
 
                 {this.props.selected && (
-                  <Col lg={4}>
+                  <Col lg={12} className="text-center pb-3">
                     {this.renderAddBlockButton(
                       this.props.intl.formatMessage(messages.addItem),
                     )}

--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/View.jsx
@@ -42,9 +42,9 @@ const AccordionView = ({ data, block }) => {
                 )}
               </div>
             </div>
-            <Row>
+            <Row className="justify-content-center">
               {data.subblocks.map((subblock, index) => (
-                <Col lg="4" key={subblock.id}>
+                <Col lg="4" key={subblock.id} className="pb-3">
                   <ViewBlock
                     data={subblock}
                     key={index}

--- a/src/components/ItaliaTheme/Blocks/Listing/Commons/utils.js
+++ b/src/components/ItaliaTheme/Blocks/Listing/Commons/utils.js
@@ -61,7 +61,7 @@ export const useSlider = (userAutoplay) => {
 
     if ((userAutoplay && !slide) || (userAutoplay && !slide.length > 0)) return;
 
-    // Custom handling of focus as per Arter a11y audit and request
+    // Custom handling of focus for a11y
     const link = visibleSlideTitle(
       `a.slide-link[data-slide="${currentSlide}"]`,
     );
@@ -70,7 +70,14 @@ export const useSlider = (userAutoplay) => {
       return;
     }
     // eslint-disable-next-line no-unused-expressions
-    else link.focus();
+    else if (
+      // if the focus was already on a slide, move it to the current one
+      Array.from(document.querySelectorAll('.slick-slide')).some((el) =>
+        el.contains(document.activeElement),
+      )
+    ) {
+      link.focus();
+    }
   };
 
   return {

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -50,7 +50,7 @@ const messages = defineMessages({
 });
 
 function NextArrow(props) {
-  // Custom handling of focus as per Arter a11y audit and request
+  // Custom handling of focus for a11y
   const { className, style, onClick, intl, currentSlide } = props;
   const handleClick = (options) => {
     onClick(options, false);
@@ -85,7 +85,7 @@ function NextArrow(props) {
 }
 
 function PrevArrow(props) {
-  // Custom handling of focus as per Arter a11y audit and request
+  // Custom handling of focus for a11y
   const {
     className,
     style,
@@ -225,7 +225,7 @@ const SliderTemplate = ({
   };
 
   const renderCustomDots = (props) => {
-    // Custom handling of focus as per Arter a11y audit and request
+    // Custom handling of focus for a11y
     return (
       <ul
         className="slick-dots"
@@ -281,13 +281,13 @@ const SliderTemplate = ({
     pauseOnDotsHover: true,
     swipe: true,
     swipeToSlide: true,
-    focusOnSelect: true,
+    focusOnSelect: false,
     draggable: true,
     accessibility: true,
     nextArrow: <NextArrow intl={intl} focusNext={focusNext} />,
     prevArrow: <PrevArrow intl={intl} focusNext={focusNext} />,
     appendDots: renderCustomDots,
-    // Custom handling of focus as per Arter a11y audit and request
+    // Custom handling of focus for a11y
     afterChange: focusNext,
     responsive: [
       {

--- a/src/config/Blocks/blocks.js
+++ b/src/config/Blocks/blocks.js
@@ -364,10 +364,9 @@ const italiaBlocks = {
 
 const getItaliaBlocks = (config) => {
   delete config.blocks.blocksConfig.teaser;
-  config.blocks.blocksConfig.gridBlock.allowedBlocks =
-    config.blocks.blocksConfig.gridBlock.allowedBlocks
-      .filter((item) => !['slate', 'teaser'].includes(item))
-      .concat(['text']);
+  config.blocks.blocksConfig.gridBlock.allowedBlocks = config.blocks.blocksConfig.gridBlock.allowedBlocks
+    .filter((item) => !['slate', 'teaser'].includes(item))
+    .concat(['text']);
   return italiaBlocks;
 };
 export default getItaliaBlocks;

--- a/src/customizations/volto/components/manage/Blocks/Grid/Edit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Grid/Edit.jsx
@@ -1,0 +1,55 @@
+/**
+ * Customizations:
+ * - make the block full-width and fix overlapping ui for
+ *   some inner blocks like image using custom class
+ */
+
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { useState } from 'react';
+import ContainerEdit from '@plone/volto/components/manage/Blocks/Container/Edit';
+
+const GridBlockEdit = (props) => {
+  const { data } = props;
+
+  const columnsLength = data?.blocks_layout?.items?.length || 0;
+  const [selectedBlock, setSelectedBlock] = useState(null);
+
+  return (
+    <div
+      className={cx({
+        one: columnsLength === 1,
+        two: columnsLength === 2,
+        three: columnsLength === 3,
+        four: columnsLength >= 4,
+        'grid-items': true,
+        'full-width': true,
+      })}
+      // This is required to enabling a small "in-between" clickable area
+      // for bringing the Grid sidebar alive once you have selected an inner block
+      onClick={(e) => {
+        if (!e.block) setSelectedBlock(null);
+      }}
+      role="presentation"
+    >
+      <div className="gridBlock-container">
+        <ContainerEdit
+          {...props}
+          selectedBlock={selectedBlock}
+          setSelectedBlock={setSelectedBlock}
+          direction="horizontal"
+        />
+      </div>
+    </div>
+  );
+};
+
+GridBlockEdit.propTypes = {
+  block: PropTypes.string.isRequired,
+  onChangeBlock: PropTypes.func.isRequired,
+  pathname: PropTypes.string.isRequired,
+  selected: PropTypes.bool.isRequired,
+  manage: PropTypes.bool.isRequired,
+};
+
+export default GridBlockEdit;

--- a/src/theme/ItaliaTheme/Blocks/_gridBlock.scss
+++ b/src/theme/ItaliaTheme/Blocks/_gridBlock.scss
@@ -1,0 +1,27 @@
+.block.gridBlock {
+  margin-top: 2rem;
+  .full-width {
+    height: unset !important;
+  }
+  .gridBlock-container {
+    max-width: 1320px;
+    padding: 0 4px;
+    margin: auto;
+    position: relative;
+    .toolbar {
+      left: 16px !important;
+    }
+    .block {
+      .image {
+        .ui.message {
+          padding-left: 8px;
+          padding-right: 8px;
+        }
+        .ui.input {
+          font-size: 14px;
+          margin-left: 16px;
+        }
+      }
+    }
+  }
+}

--- a/src/theme/site.scss
+++ b/src/theme/site.scss
@@ -88,6 +88,7 @@
 @import 'ItaliaTheme/Blocks/HTML';
 @import 'ItaliaTheme/Blocks/simpleCardTemplate';
 @import 'ItaliaTheme/Blocks/search';
+@import 'ItaliaTheme/Blocks/gridBlock';
 
 @import 'ItaliaTheme/Views/uo';
 @import 'ItaliaTheme/Views/evento';


### PR DESCRIPTION
E' stato sistemato l'allineamento orrizzontale del blocco Contatti, in modo che i contatti siano centrati orizzontalmente. 
Se infatti c'era un solo contatto, questo rimaneva allineato a sinistra.
Come era prima:
<img width="466" alt="Schermata 2023-09-14 alle 14 54 21" src="https://github.com/italia/design-comuni-plone-theme/assets/51911425/b15511d7-a6c0-40e4-9f06-2a068f1d036a">

come è ora:
<img width="723" alt="Schermata 2023-09-14 alle 14 58 18" src="https://github.com/italia/design-comuni-plone-theme/assets/51911425/dcc1380a-624b-44e0-9149-323bca534b2d">
