### PR TITLE
feat: Intestazione del footer editabile

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Migliorata l'accessibilità per il blocco Contenuti in Evidenza e per i bottoni nei sottositi
+
 ## Versione 11.4.0 (06/02/2024)
 
 ### Novità

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,6 +52,7 @@
 - Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
 - Migliorata l'accessibilità per il blocco Contenuti in Evidenza e per i bottoni nei sottositi
 - Sistemato l'html semantico degli heading per i template del Blocco Listing variazione RSS, migliorata l'esperienza d'uso per gli utenti che utilizzano screen reader
+- Migliorata l'accessibilità per i contatti, lo screen reader ora legge anche il tipo di contatto oltre al testo (ad es. Telefono: numero di telefono)
 
 ## Versione 11.4.0 (06/02/2024)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,6 +45,7 @@
 
 ### Fix
 
+- Sistemato lo skiplink "Vai al contenuto" nella pagina principale di ricerca del sito
 - Risolto un problema relativo alla navigazione da tastiera e di gestione del focus nei menu a tendina "Condividi" e "Azioni" nelle testate delle viste dei Content Type che le implementano.
 - Reso il link ai diversi social elencati parlante, ora viene riportato "Seguici su nome_del_social"
 - Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,7 @@
 - Reso il link ai diversi social elencati parlante, ora viene riportato "Seguici su nome_del_social"
 - Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
 - Migliorata l'accessibilità per il blocco Contenuti in Evidenza e per i bottoni nei sottositi
+- Sistemato l'html semantico degli heading per i template del Blocco Listing variazione RSS, migliorata l'esperienza d'uso per gli utenti che utilizzano screen reader
 
 ## Versione 11.4.0 (06/02/2024)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,8 +45,9 @@
 
 ### Fix
 
-- [ Accessibilità ] Reso il link ai diversi social elencati parlante, ora viene riportato "Seguici su nome_del_social"
-- [ Accessibilità ] Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
+- Risolto un problema relativo alla navigazione da tastiera e di gestione del focus nei menu a tendina "Condividi" e "Azioni" nelle testate delle viste dei Content Type che le implementano.
+- Reso il link ai diversi social elencati parlante, ora viene riportato "Seguici su nome_del_social"
+- Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
 - Migliorata l'accessibilità per il blocco Contenuti in Evidenza e per i bottoni nei sottositi
 
 ## Versione 11.4.0 (06/02/2024)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,9 @@
 - Sistemato l'html semantico degli heading per i template del Blocco Listing variazione RSS, migliorata l'esperienza d'uso per gli utenti che utilizzano screen reader
 - Migliorata l'accessibilità per i contatti, lo screen reader ora legge anche il tipo di contatto oltre al testo (ad es. Telefono: numero di telefono)
 
+### Novità
+- Ora la fascia del footer contenente il logo e il nome del sito è configurabile da pannello di controllo
+
 ## Versione 11.4.0 (06/02/2024)
 
 ### Novità

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,6 +56,7 @@
 
 ### Fix
 
+- [ Accessibilità ] Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
 - Sistemata la gerarchia per i titoli dentro al blocco semplice
 
 ## Versione 11.3.4 (31/01/2024)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,6 +45,7 @@
 
 ### Fix
 
+- Migliorata l'accessibilità e aggiunto elementi per migliorare l'esperienza d'uso degli utenti che utilizzano screen reader nella vista Cartella FAQ
 - Sistemato lo skiplink "Vai al contenuto" nella pagina principale di ricerca del sito
 - Risolto un problema relativo alla navigazione da tastiera e di gestione del focus nei menu a tendina "Condividi" e "Azioni" nelle testate delle viste dei Content Type che le implementano.
 - Reso il link ai diversi social elencati parlante, ora viene riportato "Seguici su nome_del_social"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,6 +45,8 @@
 
 ### Fix
 
+- [ Accessibilità ] Reso il link ai diversi social elencati parlante, ora viene riportato "Seguici su nome_del_social"
+- [ Accessibilità ] Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
 - Migliorata l'accessibilità per il blocco Contenuti in Evidenza e per i bottoni nei sottositi
 
 ## Versione 11.4.0 (06/02/2024)
@@ -56,7 +58,6 @@
 
 ### Fix
 
-- [ Accessibilità ] Rimossi gli heading per alcuni blocchi nel caso il titolo non sia presente al fine di migliorare l'esperienza con l'uso di screen reader
 - Sistemata la gerarchia per i titoli dentro al blocco semplice
 
 ## Versione 11.3.4 (31/01/2024)

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2113,6 +2113,7 @@ msgid "foto_attivita_politica"
 msgstr ""
 
 #: components/ItaliaTheme/Search/Search
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderView
 # defaultMessage: Trovati {total} risultati.
 msgid "found_n_results"
 msgstr ""

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -733,6 +733,7 @@ msgid "accordion_block"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Account
 msgid "account"
 msgstr ""
@@ -1840,6 +1841,7 @@ msgid "elementi_di_interesse"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Email
 msgid "email"
 msgstr ""
@@ -1943,6 +1945,7 @@ msgstr "Typ een trefwoord om antwoorden te vinden"
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Fax
 msgid "fax"
 msgstr ""
@@ -2300,6 +2303,7 @@ msgid "link_siti_esterni"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: LinkedIn
 msgid "linkedin"
 msgstr ""
@@ -2710,6 +2714,7 @@ msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: components/ItaliaTheme/View/VenueView/VenueContacts
+#: helpers/contentHelper
 # defaultMessage: PEC
 msgid "pec"
 msgstr ""
@@ -3619,6 +3624,7 @@ msgid "skiplink-navigation"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Skype
 msgid "skype"
 msgstr ""
@@ -3634,6 +3640,7 @@ msgid "slidesToShow"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Social
 msgid "social"
 msgstr ""
@@ -3780,6 +3787,7 @@ msgstr ""
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Tel
 msgid "telefono"
 msgstr ""
@@ -3790,6 +3798,7 @@ msgid "telefono_sede"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Telegram
 msgid "telegram"
 msgstr ""
@@ -3900,6 +3909,7 @@ msgid "trasparenza"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Twitter
 msgid "twitter"
 msgstr ""
@@ -3969,6 +3979,7 @@ msgid "update_date"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Sito web
 msgid "url"
 msgstr ""
@@ -4028,6 +4039,7 @@ msgid "vincoli"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Whatsapp
 msgid "whatsapp"
 msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2098,6 +2098,7 @@ msgid "foto_attivita_politica"
 msgstr "Photo of political activity"
 
 #: components/ItaliaTheme/Search/Search
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderView
 # defaultMessage: Trovati {total} risultati.
 msgid "found_n_results"
 msgstr "Found {total} results"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -718,6 +718,7 @@ msgid "accordion_block"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Account
 msgid "account"
 msgstr ""
@@ -1825,6 +1826,7 @@ msgid "elementi_di_interesse"
 msgstr "Elements of interest"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Email
 msgid "email"
 msgstr ""
@@ -1928,6 +1930,7 @@ msgstr "Type a keyword to find answers"
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Fax
 msgid "fax"
 msgstr "Fax"
@@ -2285,6 +2288,7 @@ msgid "link_siti_esterni"
 msgstr "Useful links"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: LinkedIn
 msgid "linkedin"
 msgstr ""
@@ -2695,6 +2699,7 @@ msgstr "Sponsored by"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: components/ItaliaTheme/View/VenueView/VenueContacts
+#: helpers/contentHelper
 # defaultMessage: PEC
 msgid "pec"
 msgstr "PEC"
@@ -3604,6 +3609,7 @@ msgid "skiplink-navigation"
 msgstr "Go to navigation"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Skype
 msgid "skype"
 msgstr ""
@@ -3619,6 +3625,7 @@ msgid "slidesToShow"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Social
 msgid "social"
 msgstr ""
@@ -3765,6 +3772,7 @@ msgstr ""
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Tel
 msgid "telefono"
 msgstr "Phone"
@@ -3775,6 +3783,7 @@ msgid "telefono_sede"
 msgstr "Phone"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Telegram
 msgid "telegram"
 msgstr ""
@@ -3885,6 +3894,7 @@ msgid "trasparenza"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Twitter
 msgid "twitter"
 msgstr ""
@@ -3954,6 +3964,7 @@ msgid "update_date"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Sito web
 msgid "url"
 msgstr ""
@@ -4013,6 +4024,7 @@ msgid "vincoli"
 msgstr "Constraints"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Whatsapp
 msgid "whatsapp"
 msgstr ""

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2107,6 +2107,7 @@ msgid "foto_attivita_politica"
 msgstr "Foto de la actividad política"
 
 #: components/ItaliaTheme/Search/Search
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderView
 # defaultMessage: Trovati {total} risultati.
 msgid "found_n_results"
 msgstr "Encontrados {total} resultados"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -727,6 +727,7 @@ msgid "accordion_block"
 msgstr "Acordeón"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Account
 msgid "account"
 msgstr ""
@@ -1834,6 +1835,7 @@ msgid "elementi_di_interesse"
 msgstr "Elementos de interés"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Email
 msgid "email"
 msgstr ""
@@ -1937,6 +1939,7 @@ msgstr "Escriba una palabra clave para encontrar respuestas"
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Fax
 msgid "fax"
 msgstr "Fax"
@@ -2294,6 +2297,7 @@ msgid "link_siti_esterni"
 msgstr "Enlaces útiles"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: LinkedIn
 msgid "linkedin"
 msgstr ""
@@ -2704,6 +2708,7 @@ msgstr "Patrocinado por"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: components/ItaliaTheme/View/VenueView/VenueContacts
+#: helpers/contentHelper
 # defaultMessage: PEC
 msgid "pec"
 msgstr "PEC"
@@ -3613,6 +3618,7 @@ msgid "skiplink-navigation"
 msgstr "Ir a navegación"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Skype
 msgid "skype"
 msgstr ""
@@ -3628,6 +3634,7 @@ msgid "slidesToShow"
 msgstr "N° diapositivas para mostrar"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Social
 msgid "social"
 msgstr ""
@@ -3774,6 +3781,7 @@ msgstr "Con el apoyo de"
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Tel
 msgid "telefono"
 msgstr "Teléfono"
@@ -3784,6 +3792,7 @@ msgid "telefono_sede"
 msgstr "Teléfono"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Telegram
 msgid "telegram"
 msgstr ""
@@ -3894,6 +3903,7 @@ msgid "trasparenza"
 msgstr "Transparencia"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Twitter
 msgid "twitter"
 msgstr ""
@@ -3963,6 +3973,7 @@ msgid "update_date"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Sito web
 msgid "url"
 msgstr ""
@@ -4022,6 +4033,7 @@ msgid "vincoli"
 msgstr "Restricciones"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Whatsapp
 msgid "whatsapp"
 msgstr ""

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2115,6 +2115,7 @@ msgid "foto_attivita_politica"
 msgstr "Photo d'activité politique"
 
 #: components/ItaliaTheme/Search/Search
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderView
 # defaultMessage: Trovati {total} risultati.
 msgid "found_n_results"
 msgstr "{total} résultats trouvés"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -735,6 +735,7 @@ msgid "accordion_block"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Account
 msgid "account"
 msgstr ""
@@ -1842,6 +1843,7 @@ msgid "elementi_di_interesse"
 msgstr "Objets d'intérêt"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Email
 msgid "email"
 msgstr ""
@@ -1945,6 +1947,7 @@ msgstr "Tapez un mot-clé pour trouver des réponses"
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Fax
 msgid "fax"
 msgstr ""
@@ -2302,6 +2305,7 @@ msgid "link_siti_esterni"
 msgstr "Liens utiles"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: LinkedIn
 msgid "linkedin"
 msgstr ""
@@ -2712,6 +2716,7 @@ msgstr "Sponsorisé par"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: components/ItaliaTheme/View/VenueView/VenueContacts
+#: helpers/contentHelper
 # defaultMessage: PEC
 msgid "pec"
 msgstr "PEC"
@@ -3621,6 +3626,7 @@ msgid "skiplink-navigation"
 msgstr "Aller à la navigation"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Skype
 msgid "skype"
 msgstr ""
@@ -3636,6 +3642,7 @@ msgid "slidesToShow"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Social
 msgid "social"
 msgstr ""
@@ -3782,6 +3789,7 @@ msgstr ""
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Tel
 msgid "telefono"
 msgstr "Tél."
@@ -3792,6 +3800,7 @@ msgid "telefono_sede"
 msgstr "Téléphone"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Telegram
 msgid "telegram"
 msgstr ""
@@ -3902,6 +3911,7 @@ msgid "trasparenza"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Twitter
 msgid "twitter"
 msgstr ""
@@ -3971,6 +3981,7 @@ msgid "update_date"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Sito web
 msgid "url"
 msgstr ""
@@ -4030,6 +4041,7 @@ msgid "vincoli"
 msgstr "Contraintes"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Whatsapp
 msgid "whatsapp"
 msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2098,6 +2098,7 @@ msgid "foto_attivita_politica"
 msgstr "Foto dell'attività politica"
 
 #: components/ItaliaTheme/Search/Search
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderView
 # defaultMessage: Trovati {total} risultati.
 msgid "found_n_results"
 msgstr "Trovati {total} risultati"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -718,6 +718,7 @@ msgid "accordion_block"
 msgstr "Accordion"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Account
 msgid "account"
 msgstr "Account"
@@ -1825,6 +1826,7 @@ msgid "elementi_di_interesse"
 msgstr "Elementi di interesse"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Email
 msgid "email"
 msgstr "E-mail"
@@ -1928,6 +1930,7 @@ msgstr "Digita una parola chiave per trovare le risposte"
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Fax
 msgid "fax"
 msgstr "Fax"
@@ -2285,6 +2288,7 @@ msgid "link_siti_esterni"
 msgstr "Link utili"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: LinkedIn
 msgid "linkedin"
 msgstr "LinkedIn"
@@ -2695,6 +2699,7 @@ msgstr "Patrocinato da"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: components/ItaliaTheme/View/VenueView/VenueContacts
+#: helpers/contentHelper
 # defaultMessage: PEC
 msgid "pec"
 msgstr "PEC"
@@ -3604,6 +3609,7 @@ msgid "skiplink-navigation"
 msgstr "Vai alla navigazione"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Skype
 msgid "skype"
 msgstr "Skype"
@@ -3619,6 +3625,7 @@ msgid "slidesToShow"
 msgstr "N° slide da mostrare"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Social
 msgid "social"
 msgstr "Social"
@@ -3765,6 +3772,7 @@ msgstr "Con il supporto di"
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Tel
 msgid "telefono"
 msgstr "Telefono"
@@ -3775,6 +3783,7 @@ msgid "telefono_sede"
 msgstr "Telefono"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Telegram
 msgid "telegram"
 msgstr "Telegram"
@@ -3885,6 +3894,7 @@ msgid "trasparenza"
 msgstr "Trasparenza"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Twitter
 msgid "twitter"
 msgstr "Twitter"
@@ -3954,6 +3964,7 @@ msgid "update_date"
 msgstr "Data di aggiornamento"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Sito web
 msgid "url"
 msgstr "Sito web"
@@ -4013,6 +4024,7 @@ msgid "vincoli"
 msgstr "Vincoli"
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Whatsapp
 msgid "whatsapp"
 msgstr "Whatsapp"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-01-15T16:05:18.583Z\n"
+"POT-Creation-Date: 2024-02-01T14:18:45.551Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2100,6 +2100,7 @@ msgid "foto_attivita_politica"
 msgstr ""
 
 #: components/ItaliaTheme/Search/Search
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderView
 # defaultMessage: Trovati {total} risultati.
 msgid "found_n_results"
 msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-02-01T14:18:45.551Z\n"
+"POT-Creation-Date: 2024-02-08T09:29:49.246Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -720,6 +720,7 @@ msgid "accordion_block"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Account
 msgid "account"
 msgstr ""
@@ -1827,6 +1828,7 @@ msgid "elementi_di_interesse"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Email
 msgid "email"
 msgstr ""
@@ -1930,6 +1932,7 @@ msgstr ""
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Fax
 msgid "fax"
 msgstr ""
@@ -2287,6 +2290,7 @@ msgid "link_siti_esterni"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: LinkedIn
 msgid "linkedin"
 msgstr ""
@@ -2697,6 +2701,7 @@ msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
 #: components/ItaliaTheme/View/VenueView/VenueContacts
+#: helpers/contentHelper
 # defaultMessage: PEC
 msgid "pec"
 msgstr ""
@@ -3606,6 +3611,7 @@ msgid "skiplink-navigation"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Skype
 msgid "skype"
 msgstr ""
@@ -3621,6 +3627,7 @@ msgid "slidesToShow"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Social
 msgid "social"
 msgstr ""
@@ -3767,6 +3774,7 @@ msgstr ""
 
 #: components/ItaliaTheme/View/Commons/ContactLink
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Tel
 msgid "telefono"
 msgstr ""
@@ -3777,6 +3785,7 @@ msgid "telefono_sede"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Telegram
 msgid "telegram"
 msgstr ""
@@ -3887,6 +3896,7 @@ msgid "trasparenza"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Twitter
 msgid "twitter"
 msgstr ""
@@ -3956,6 +3966,7 @@ msgid "update_date"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Sito web
 msgid "url"
 msgstr ""
@@ -4015,6 +4026,7 @@ msgid "vincoli"
 msgstr ""
 
 #: components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView
+#: helpers/contentHelper
 # defaultMessage: Whatsapp
 msgid "whatsapp"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "typeface-lora": "0.0.72",
     "typeface-roboto-mono": "0.0.75",
     "typeface-titillium-web": "0.0.72",
-    "volto-blocks-widget": "3.1.0",
+    "volto-blocks-widget": "3.4.0",
     "volto-data-grid-widget": "2.3.1",
     "volto-dropdownmenu": "4.1.1",
     "volto-editablefooter": "5.0.3",

--- a/src/components/ItaliaTheme/Blocks/CountDown/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/CountDown/Body.jsx
@@ -50,7 +50,9 @@ const Body = ({ block, sections, data }) => {
       <SearchSectionsBackground />
       <div className="container">
         <div className="searchContainer d-flex w-100">
-          <h2 className="text-secondary mb-4">{block.title}</h2>
+          {block.title && (
+            <h2 className="text-secondary mb-4">{block.title}</h2>
+          )}
           <div className="searchbar lightgrey-bg-c2 shadow-sm rounded d-flex w-100">
             <input
               className="inputSearch lightgrey-bg-c2"

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate.jsx
@@ -82,7 +82,9 @@ const CardWithImageRssTemplate = ({
                         {getViewDate(item.pubDate || item.date, intl.locale)}
                       </span>{' '}
                     </div>
-                    <CardTitle tag="h6">{item.title}</CardTitle>
+                    <CardTitle tag="h3" className="h6">
+                      {item.title}
+                    </CardTitle>
                     {item?.source?.length > 0 && (
                       <div className="source-title">
                         <span className="source">{item.source}</span>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate.jsx
@@ -70,7 +70,9 @@ const CardWithoutImageRssTemplate = ({
                         </span>
                       )}
                     </div>
-                    <CardTitle tag="h5">{item.title}</CardTitle>
+                    <CardTitle tag="h3" className="h6">
+                      {item.title}
+                    </CardTitle>
                     {item?.source?.length > 0 && (
                       <div className="source-title">
                         <span className="source">{item.source}</span>

--- a/src/components/ItaliaTheme/Blocks/RssBlock/TemplatesSkeleton/CardWithImageRssTemplateSkeleton.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/TemplatesSkeleton/CardWithImageRssTemplateSkeleton.jsx
@@ -34,7 +34,7 @@ const CardWithImageRssTemplateSkeleton = ({ isEditMode, data = {} }) => {
 
                 <CardBody tag="div" className="px-4">
                   <div className="category-top"></div>
-                  <CardTitle tag="h6"></CardTitle>
+                  <CardTitle tag="h3" className="h6"></CardTitle>
                 </CardBody>
                 <CardReadMore
                   iconName="it-arrow-right"

--- a/src/components/ItaliaTheme/Blocks/RssBlock/TemplatesSkeleton/CardWithoutImageRssTemplateSkeleton.jsx
+++ b/src/components/ItaliaTheme/Blocks/RssBlock/TemplatesSkeleton/CardWithoutImageRssTemplateSkeleton.jsx
@@ -28,7 +28,7 @@ const CardWithoutImageRssTemplateSkeleton = ({ isEditMode, data = {} }) => {
               <Card noWrapper={false} tag="div">
                 <CardBody tag="div">
                   <div className="category-top"></div>
-                  <CardTitle tag="h5"></CardTitle>
+                  <CardTitle tag="h3" className="h6"></CardTitle>
                   <CardText tag="p" className="font-serif"></CardText>
                 </CardBody>
                 <CardReadMore

--- a/src/components/ItaliaTheme/Blocks/SearchSections/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/SearchSections/Body.jsx
@@ -52,7 +52,9 @@ const Body = ({ block, sections }) => {
       )}
       <div className="container">
         <div className="searchContainer d-flex w-100">
-          <h2 className="search-section-title mb-4">{block.title}</h2>
+          {block.title && (
+            <h2 className="search-section-title mb-4">{block.title}</h2>
+          )}
           <div className="searchbar shadow-sm rounded d-flex w-100">
             <button
               className="rounded-start"

--- a/src/components/ItaliaTheme/Footer/FooterMain.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterMain.jsx
@@ -15,12 +15,16 @@ import {
   FooterPNRRLogo,
 } from 'design-comuni-plone-theme/components/ItaliaTheme/';
 
+import { FooterTop } from 'volto-editablefooter';
+
 /**
  * FooterMain component class.
  * @class FooterMain
  * @extends Component
  */
 const FooterMain = () => {
+  const footerTopContent = FooterTop();
+
   return (
     <div className="it-footer-main">
       <Container tag="div">
@@ -28,11 +32,15 @@ const FooterMain = () => {
           <Row className="clearfix" tag="div">
             <Col sm={12} tag="div" widths={['xs', 'sm', 'md', 'lg', 'xl']}>
               <div className="it-brand-wrapper">
-                <FooterPNRRLogo />
-                <UniversalLink href="/">
-                  <LogoFooter />
-                  <BrandTextFooter />
-                </UniversalLink>
+                {footerTopContent ?? (
+                  <>
+                    <FooterPNRRLogo />
+                    <UniversalLink href="/">
+                      <LogoFooter />
+                      <BrandTextFooter />
+                    </UniversalLink>
+                  </>
+                )}
               </div>
             </Col>
           </Row>

--- a/src/components/ItaliaTheme/Header/SocialHeader.jsx
+++ b/src/components/ItaliaTheme/Header/SocialHeader.jsx
@@ -50,9 +50,9 @@ const SocialHeader = () => {
           {socials?.map((social, idx) => (
             <li key={idx}>
               <a
-                title={
-                  social.title + ' ' + intl.formatMessage(messages.socialOpen)
-                }
+                title={`${intl.formatMessage(messages.followUs)} ${
+                  social.title
+                } ${intl.formatMessage(messages.socialOpen)}`}
                 href={social.url}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/ItaliaTheme/Search/Search.jsx
+++ b/src/components/ItaliaTheme/Search/Search.jsx
@@ -357,7 +357,7 @@ const Search = () => {
     <>
       <Helmet title={intl.formatMessage(messages.searchResults)} />
 
-      <div className="public-ui search-view">
+      <div className="public-ui search-view" id="view">
         <Container className="px-4 my-4">
           <Row>
             <Col>

--- a/src/components/ItaliaTheme/View/Commons/ContactsCard.jsx
+++ b/src/components/ItaliaTheme/View/Commons/ContactsCard.jsx
@@ -5,10 +5,11 @@ import { getContent, resetContent } from '@plone/volto/actions';
 import { UniversalLink } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { renderPDCItemValue } from 'design-comuni-plone-theme/helpers';
+import { useIntl } from 'react-intl';
 
 const ContactsCard = ({ contact = {}, show_title = false, ...rest }) => {
   const dispatch = useDispatch();
-
+  const intl = useIntl();
   const contactUrl = contact['@id'];
 
   const { loading, loaded, error, data } = useSelector(
@@ -59,7 +60,7 @@ const ContactsCard = ({ contact = {}, show_title = false, ...rest }) => {
                 {pdc.pdc_type}
                 {pdc.pdc_desc ? ` - ${pdc.pdc_desc}` : ''}:{' '}
               </strong>
-              {renderPDCItemValue(pdc)}
+              {renderPDCItemValue(pdc, intl)}
             </span>
           )) ?? null}
         </CardText>

--- a/src/components/ItaliaTheme/View/Commons/Sharing.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Sharing.jsx
@@ -85,7 +85,13 @@ const Sharing = ({ url, title }) => {
       <DropdownMenu>
         <LinkList>
           {socials.map((item, i) => (
-            <LinkListItem href={item.url} key={item.id} target="_target">
+            <LinkListItem
+              href={item.url}
+              key={item.id}
+              target="_target"
+              role="menuitem"
+              tabIndex={-1}
+            >
               <Icon
                 className={undefined}
                 color=""

--- a/src/components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderView.jsx
+++ b/src/components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderView.jsx
@@ -31,6 +31,10 @@ const messages = defineMessages({
     id: 'Faq Folder: Nessun risultato trovato',
     defaultMessage: 'Non ho trovato la risposta che cercavi',
   },
+  foundNResults: {
+    id: 'found_n_results',
+    defaultMessage: 'Trovati {total} risultati.',
+  },
 });
 
 /**
@@ -46,7 +50,6 @@ const FaqFolderView = ({ content }) => {
   const FAQ_FOLDER_KEY = 'FAQ_FOLDER';
   const structure_url = content?.['@components']?.['faq-structure']?.['@id'];
   const dispatch = useDispatch();
-  //const intl = useIntl();
 
   const faq_structure = useSelector(
     (state) => state.content.subrequests?.[FAQ_FOLDER_KEY],
@@ -79,7 +82,7 @@ const FaqFolderView = ({ content }) => {
 
   useDebouncedEffect(
     () => {
-      return doSearch();
+      doSearch();
     }, // eslint-disable-next-line react-hooks/exhaustive-deps
     600,
     [searchableText],
@@ -106,25 +109,39 @@ const FaqFolderView = ({ content }) => {
       <Container className="px-4">
         <TextOrBlocks content={content} />
 
-        {faq_structure && (
-          <>
-            {faq_structure?.loaded &&
-              searchableText?.length > 0 &&
-              faq_structure.data?.items?.length === 0 && (
-                <>{intl.formatMessage(messages.no_results)}</>
+        <div
+          className="faq-search-results-wrapper"
+          id="faq-search-results-region"
+          aria-live="polite"
+        >
+          {faq_structure && (
+            <>
+              {faq_structure.loaded && (
+                <p className="visually-hidden d-lg-block" aria-live="polite">
+                  {intl.formatMessage(messages.foundNResults, {
+                    total: faq_structure?.data?.items?.[0]?.items?.length || 0,
+                  })}
+                </p>
+              )}
+              {faq_structure?.loaded &&
+                searchableText?.length > 0 &&
+                faq_structure.data?.items?.[0]?.items?.length === 0 && (
+                  <p>{intl.formatMessage(messages.no_results)}</p>
+                )}
+
+              {faq_structure?.loading && (
+                <div className="mt-5 mb-5 loading">
+                  <Spinner active double={false} small={false} tag="div" />
+                </div>
               )}
 
-            {faq_structure?.loading && (
-              <div className="mt-5 mb-5 loading">
-                <Spinner active double={false} small={false} tag="div" />
-              </div>
-            )}
-
-            {!faq_structure?.loading && faq_structure.data?.items?.[0] && (
-              <FaqFolderTree tree={faq_structure.data.items[0]} />
-            )}
-          </>
-        )}
+              {!faq_structure?.loading &&
+                faq_structure.data?.items?.length > 0 && (
+                  <FaqFolderTree tree={faq_structure.data.items[0]} />
+                )}
+            </>
+          )}
+        </div>
 
         <PageMetadata content={content} />
       </Container>

--- a/src/components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar.jsx
+++ b/src/components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar.jsx
@@ -66,6 +66,7 @@ const SearchBar = ({ searchableText, setSearchableText }) => {
                 setSearchableText(e?.target?.value || '');
               }}
               type="text"
+              aria-controls="faq-search-results-region"
             />
           </div>
         </div>

--- a/src/components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView.jsx
+++ b/src/components/ItaliaTheme/View/PuntoDiContattoView/PuntoDiContattoView.jsx
@@ -110,7 +110,9 @@ const PuntoDiContattoView = (props) => {
                       ? pdc?.pdc_type
                       : intl.formatMessage(messages[pdc.pdc_type])}
                     {pdc?.pdc_desc && ` - ${pdc.pdc_desc}`}:
-                    <span className="ms-1">{renderPDCItemValue(pdc)}</span>
+                    <span className="ms-1">
+                      {renderPDCItemValue(pdc, intl)}
+                    </span>
                   </h5>
                 </div>
               );

--- a/src/helpers/contentHelper.js
+++ b/src/helpers/contentHelper.js
@@ -1,4 +1,56 @@
 import { UniversalLink } from '@plone/volto/components';
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  url: {
+    id: 'url',
+    defaultMessage: 'Sito web',
+  },
+  account: {
+    id: 'account',
+    defaultMessage: 'Account',
+  },
+  linkedin: {
+    id: 'linkedin',
+    defaultMessage: 'LinkedIn',
+  },
+  twitter: {
+    id: 'twitter',
+    defaultMessage: 'Twitter',
+  },
+  telefono: {
+    id: 'telefono',
+    defaultMessage: 'Numero di telefono',
+  },
+  email: {
+    id: 'email',
+    defaultMessage: 'Email',
+  },
+  pec: {
+    id: 'pec',
+    defaultMessage: 'PEC',
+  },
+  social: {
+    id: 'social',
+    defaultMessage: 'Social',
+  },
+  fax: {
+    id: 'fax',
+    defaultMessage: 'Fax',
+  },
+  whatsapp: {
+    id: 'whatsapp',
+    defaultMessage: 'Whatsapp',
+  },
+  telegram: {
+    id: 'telegram',
+    defaultMessage: 'Telegram',
+  },
+  skype: {
+    id: 'skype',
+    defaultMessage: 'Skype',
+  },
+});
 
 export const contentFolderHasItems = (content, folder_name) => {
   const has_items =
@@ -7,14 +59,19 @@ export const contentFolderHasItems = (content, folder_name) => {
   return has_items;
 };
 
-export const renderPDCItemValue = (pdcValue) => {
+export const renderPDCItemValue = (pdcValue, intl) => {
   switch (pdcValue?.pdc_type) {
     case 'url':
     case 'account':
     case 'linkedin':
     case 'twitter':
       return (
-        <UniversalLink href={`${pdcValue?.pdc_value}`}>
+        <UniversalLink
+          href={`${pdcValue?.pdc_value}`}
+          aria-label={`${intl.formatMessage(messages[pdcValue.pdc_type])}: ${
+            pdcValue?.pdc_value ?? ''
+          }`}
+        >
           {pdcValue?.pdc_value}
         </UniversalLink>
       );
@@ -24,6 +81,9 @@ export const renderPDCItemValue = (pdcValue) => {
           href={`tel:${pdcValue?.pdc_value}`}
           target="_blank"
           rel="noopener noreferrer"
+          aria-label={`${intl.formatMessage(messages[pdcValue.pdc_type])}: ${
+            pdcValue?.pdc_value ?? ''
+          }`}
         >
           {pdcValue?.pdc_value}
         </a>
@@ -34,6 +94,9 @@ export const renderPDCItemValue = (pdcValue) => {
           href={`https://wa.me/${pdcValue?.pdc_value.replace(/\D/g, '')}`}
           target="_blank"
           rel="noopener noreferrer"
+          aria-label={`${intl.formatMessage(messages[pdcValue.pdc_type])}: ${
+            pdcValue?.pdc_value ?? ''
+          }`}
         >
           {pdcValue?.pdc_value}
         </a>
@@ -45,6 +108,9 @@ export const renderPDCItemValue = (pdcValue) => {
           href={`https://t.me/${pdcValue?.pdc_value}`}
           target="_blank"
           rel="noopener noreferrer"
+          aria-label={`${intl.formatMessage(messages[pdcValue.pdc_type])}: ${
+            pdcValue?.pdc_value ?? ''
+          }`}
         >
           {pdcValue?.pdc_value}
         </a>
@@ -58,6 +124,9 @@ export const renderPDCItemValue = (pdcValue) => {
           href={`skype:${pdcValue?.pdc_value}?call`}
           target="_blank"
           rel="noopener noreferrer"
+          aria-label={`${intl.formatMessage(messages[pdcValue.pdc_type])}: ${
+            pdcValue?.pdc_value ?? ''
+          }`}
         >
           {pdcValue?.pdc_value}
         </a>
@@ -69,6 +138,9 @@ export const renderPDCItemValue = (pdcValue) => {
           href={`mailto:${pdcValue?.pdc_value}`}
           target="_blank"
           rel="noopener noreferrer"
+          aria-label={`${intl.formatMessage(messages[pdcValue.pdc_type])}: ${
+            pdcValue?.pdc_value ?? ''
+          }`}
         >
           {pdcValue?.pdc_value}
         </a>

--- a/src/theme/ItaliaTheme/Components/_sharing.scss
+++ b/src/theme/ItaliaTheme/Components/_sharing.scss
@@ -8,9 +8,11 @@
     ul {
       li {
         a.list-item,
+        a.list-item a,
         button.btn-link {
           display: flex;
           align-items: center;
+          font-size: var(--bs-dropdown-font-size);
 
           .icon {
             width: 28px;

--- a/src/theme/ItaliaTheme/Subsites/ItaliaTheme/Blocks/_highlitedContent.scss
+++ b/src/theme/ItaliaTheme/Subsites/ItaliaTheme/Blocks/_highlitedContent.scss
@@ -10,7 +10,8 @@
     .bg-primary {
       .card .card-body {
         .categoryicon-top {
-          span {
+          .text,
+          .data {
             color: $subsite-primary-text;
           }
 
@@ -55,7 +56,8 @@
     .bg-secondary {
       .card .card-body {
         .categoryicon-top {
-          .text {
+          .text,
+          .data {
             color: $subsite-secondary-text;
           }
 

--- a/src/theme/ItaliaTheme/Subsites/ItaliaTheme/Blocks/_highlitedContent.scss
+++ b/src/theme/ItaliaTheme/Subsites/ItaliaTheme/Blocks/_highlitedContent.scss
@@ -39,6 +39,7 @@
 
         .chip.chip-primary {
           border-color: $subsite-primary-text;
+
           & > .chip-label {
             color: $subsite-primary-text;
           }
@@ -85,13 +86,16 @@
 
         .chip.chip-primary {
           border-color: $subsite-secondary-text;
+
           > .chip-label {
             color: $subsite-secondary-text;
           }
+
           &:hover,
           &:active {
             border-color: $subsite-secondary;
             background-color: $subsite-secondary-text;
+
             > .chip-label {
               color: $subsite-secondary;
             }

--- a/src/theme/ItaliaTheme/Subsites/ItaliaTheme/_common.scss
+++ b/src/theme/ItaliaTheme/Subsites/ItaliaTheme/_common.scss
@@ -14,6 +14,7 @@
 ) {
   .btn-tertiary {
     @include button-variant($subsite-tertiary, $subsite-tertiary-text);
+    color: $subsite-tertiary-text !important;
 
     svg {
       fill: $subsite-tertiary-text;

--- a/src/theme/ItaliaTheme/Subsites/ItaliaTheme/_common.scss
+++ b/src/theme/ItaliaTheme/Subsites/ItaliaTheme/_common.scss
@@ -57,6 +57,7 @@
   .text-primary {
     color: $subsite-primary-text !important;
   }
+
   .select-pill.text-primary {
     @if ($subsite-light-theme) {
       color: $subsite-link-color !important;
@@ -320,8 +321,8 @@
     }
 
     td.CalendarDay__hovered_span {
-      background: $subsite-primary-a0;
       border: $subsite-primary-a0;
+      background: $subsite-primary-a0;
       color: $subsite-link-color;
     }
 

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -332,6 +332,36 @@ iframe {
   }
 }
 
+//fix footer styles for volto-editablefooter footerTop field
+.it-footer .it-footer-main .it-brand-wrapper .footerTop,
+.footer-configuration-widget .footer-top-segment .block.gridBlock .grid-items {
+  h2 {
+    font-size: 1.777778rem;
+    font-weight: 600;
+    letter-spacing: unset;
+    line-height: 1.1;
+    margin-bottom: 0;
+  }
+
+  h3 {
+    font-weight: 600;
+  }
+
+  .block.image img {
+    height: 75px;
+    width: auto;
+  }
+
+  .block.gridBlock {
+    .col {
+      &:has(.block.image) {
+        width: auto;
+        flex: 0 0 auto;
+      }
+    }
+  }
+}
+
 .bg-light {
   --bs-light-rgb: #{red($primary-a0)}, #{green($primary-a0)},
     #{blue($primary-a0)};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6571,7 +6571,7 @@ __metadata:
     typeface-lora: 0.0.72
     typeface-roboto-mono: 0.0.75
     typeface-titillium-web: 0.0.72
-    volto-blocks-widget: 3.1.0
+    volto-blocks-widget: 3.4.0
     volto-data-grid-widget: 2.3.1
     volto-dropdownmenu: 4.1.1
     volto-editablefooter: 5.0.3
@@ -14302,12 +14302,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-blocks-widget@npm:3.1.0":
-  version: 3.1.0
-  resolution: "volto-blocks-widget@npm:3.1.0"
+"volto-blocks-widget@npm:3.4.0":
+  version: 3.4.0
+  resolution: "volto-blocks-widget@npm:3.4.0"
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
-  checksum: 91fc5fc102acdf17f8a8f733aef4331622246fc6b008a1c486dd21b08b71583332b53d32bb4a2b75529edaa5f740421c913e04a9565c09d03fbab41c5d700978
+  checksum: 355675359cc64b23c0357de8b952195a9693543a7e95c2c1f463b65fc7bd081d64aca8f2086e95775d5771f7071d681276f18a968e666dbead40e2c48ee9843a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ora l'intestazione del footer, quella contenente logo e nome del sito, è editabile da pannello di controllo.
Se nel pannello di controllo non è stata definita una configurazione, viene mostrata l'intestazione statica del footer. 


https://github.com/italia/design-comuni-plone-theme/assets/51911425/dcdd4d74-7594-4ebe-9a68-4bbd445ba8ec



Nota: prima di mergiare questa pr è necessario rilasciare volto-editablefooter