### PR TITLE
fix: image full width edit

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- La descrizione nelle card per i punti di contatto non mostrano più tutte le iniziali in maiuscolo.
+
 ## Versione 11.5.1 (19/02/2024)
 
 ### Migliorie

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,7 @@
 ### Fix
 
 - La descrizione nelle card per i punti di contatto non mostrano più tutte le iniziali in maiuscolo.
+- Il colore dei link nel menu mobile è ora accessibile per tutti i temi.
 
 ## Versione 11.5.1 (19/02/2024)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,6 +45,7 @@
 
 ### Fix
 
+- L'icona per aprire il menu in mobile è ora visibile anche quando l'header del sito è bianca.
 - La descrizione nelle card per i punti di contatto non mostrano più tutte le iniziali in maiuscolo.
 - Il colore dei link nel menu mobile è ora accessibile per tutti i temi.
 

--- a/src/components/ItaliaTheme/View/Commons/ContactsCard.jsx
+++ b/src/components/ItaliaTheme/View/Commons/ContactsCard.jsx
@@ -57,8 +57,10 @@ const ContactsCard = ({ contact = {}, show_title = false, ...rest }) => {
           {data?.value_punto_contatto.map((pdc, index) => (
             <span key={index}>
               <strong>
-                {pdc.pdc_type}
-                {pdc.pdc_desc ? ` - ${pdc.pdc_desc}` : ''}:{' '}
+                <span className="pdc-type">{pdc.pdc_type}</span>
+                <span className="pdc-desc">
+                  {pdc.pdc_desc ? ` - ${pdc.pdc_desc}` : ''}:{' '}
+                </span>
               </strong>
               {renderPDCItemValue(pdc, intl)}
             </span>

--- a/src/theme/ItaliaTheme/Components/_contactsCard.scss
+++ b/src/theme/ItaliaTheme/Components/_contactsCard.scss
@@ -9,7 +9,7 @@
       flex: 1 1 100%;
     }
 
-    strong {
+    .pdc-type {
       font-weight: 600;
       text-transform: capitalize;
     }

--- a/src/theme/ItaliaTheme/Components/_parentSiteMenu.scss
+++ b/src/theme/ItaliaTheme/Components/_parentSiteMenu.scss
@@ -39,7 +39,7 @@
       margin-top: 1.5rem;
       margin-bottom: 1.5rem;
       margin-left: 1.5rem;
-      background: rgba(92, 111, 130, 0.5);
+      background: rgba($primary, 0.5);
       content: '';
     }
 

--- a/src/theme/ItaliaTheme/Subsites/_mixin.scss
+++ b/src/theme/ItaliaTheme/Subsites/_mixin.scss
@@ -70,7 +70,7 @@
       );
       @include bs-brandtext.text($subsite-primary, $subsite-primary-text);
       @include bs-headernavbar.navbar($subsite-primary);
-      @include bs-headerslim.header($subsite-primary-text);
+      @include bs-headerslim.header($subsite-primary-text, $subsite-link-color);
       @include bs-navigation.nav(
         $subsite-light-theme,
         $subsite-primary,

--- a/src/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_headerslim.scss
+++ b/src/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_headerslim.scss
@@ -1,6 +1,6 @@
 @use '../../all_variables' as *;
 
-@mixin header($subsite-primary-text) {
+@mixin header($subsite-primary-text, $subsite-link-color) {
   &.cms-ui .public-ui {
     .it-header-slim-wrapper {
       .it-header-slim-wrapper-content {
@@ -34,7 +34,7 @@
     .parent-site-menu {
       li.nav-item {
         a.nav-link {
-          color: $subsite-primary-text;
+          color: $subsite-link-color;
         }
       }
     }

--- a/src/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_navigation.scss
+++ b/src/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_navigation.scss
@@ -132,7 +132,20 @@
         .navbar-nav {
           li a.nav-link {
             font-size: 16px;
+            color: $subsite-link-color;
+
+            &.active {
+              border-left-color: $subsite-link-color;
+            }
+
+            svg {
+              fill: $subsite-link-color !important;
+            }
           }
+        }
+
+        .it-socials ul li .icon {
+          fill: $subsite-link-color;
         }
 
         .link-list-wrapper {

--- a/src/theme/ItaliaTheme/Views/_common.scss
+++ b/src/theme/ItaliaTheme/Views/_common.scss
@@ -68,14 +68,39 @@ picture.volto-image.responsive img.full-width,
   margin-left: -50vw !important;
   object-fit: cover;
 
+  $toolbar-width: 80px;
+  $toolbar-collapsed-width: 20px;
+  $sidebar-width: 375px;
+  $sidebar-collapsed-width: 20px;
+
   .has-toolbar & {
-    left: calc(50% + 40px);
-    width: calc(100vw - 80px) !important;
+    left: calc(50% + calc($toolbar-width / 2));
+    width: calc(100vw - $toolbar-width) !important;
+  }
+  .has-toolbar.has-sidebar & {
+    $toolbars-width: calc($toolbar-width + $sidebar-width);
+    left: calc(50% + calc($toolbars-width / 2));
+    width: calc(100vw - $toolbars-width) !important;
+  }
+  .has-toolbar.has-sidebar-collapsed & {
+    $toolbars-width: calc($toolbar-width + $sidebar-collapsed-width);
+    left: calc(50% + calc($toolbars-width / 2));
+    width: calc(100vw - $toolbars-width) !important;
   }
 
   .has-toolbar-collapsed & {
-    left: calc(50% + 10px);
-    width: calc(100vw - 20px) !important;
+    left: calc(50% + calc($toolbar-collapsed-width / 2));
+    width: calc(100vw - $toolbar-collapsed-width) !important;
+  }
+  .has-toolbar-collapsed.has-sidebar & {
+    $toolbars-width: calc($toolbar-collapsed-width + $sidebar-width);
+    left: calc(50% + calc($toolbars-width / 2));
+    width: calc(100vw - $toolbars-width) !important;
+  }
+  .has-toolbar-collapsed.has-sidebar-collapsed & {
+    $toolbars-width: calc($toolbar-collapsed-width + $sidebar-collapsed-width);
+    left: calc(50% + calc($toolbars-width / 2));
+    width: calc(100vw - $toolbars-width) !important;
   }
 }
 

--- a/src/theme/ItaliaTheme/_white-header.scss
+++ b/src/theme/ItaliaTheme/_white-header.scss
@@ -55,7 +55,7 @@
     }
     @media (max-width: map-get($map: $grid-breakpoints, $key: 'lg') - 1px) {
       button.custom-navbar-toggler svg.icon {
-        fill: $primary;
+        fill: color-contrast($primary);
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8786,9 +8786,9 @@ __metadata:
   linkType: hard
 
 "ip@npm:^1.1.8":
-  version: 1.1.8
-  resolution: "ip@npm:1.1.8"
-  checksum: a2ade53eb339fb0cbe9e69a44caab10d6e3784662285eb5d2677117ee4facc33a64679051c35e0dfdb1a3983a51ce2f5d2cb36446d52e10d01881789b76e28fb
+  version: 1.1.9
+  resolution: "ip@npm:1.1.9"
+  checksum: b6d91fd45a856e3bd6d4f601ea0619d90f3517638f6918ebd079f959a8a6308568d8db5ef4fdf037e0d9cfdcf264f46833dfeea81ca31309cf0a7eb4b1307b84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Sistemata la visualizzazione dell'immagine a tutta larghezza in modalità di edit. 
Non veniva considerata la larghezza della sidebar aperta/chiusa (ma solo la larghezza della toolbar) per cui l'immagine risultava shiftata a sinistra in modalità di edit, e non corrispondeva al risultato finale visualizzato al salvataggio. 

Ora si vede bene: 

https://github.com/italia/design-comuni-plone-theme/assets/51911425/a0a10388-d39e-4e20-83e0-61a8c78c2968

