### PR TITLE
Link headerslim cms

### DIFF
--- a/src/theme/_cms-ui.scss
+++ b/src/theme/_cms-ui.scss
@@ -108,11 +108,9 @@ body.cms-ui {
     }
   }
 
-  .public-ui {
-    :not(.it-header-wrapper) {
-      a:not(.btn) {
-        color: $link-color;
-      }
+  .public-ui:not(:has(.it-header-wrapper)) {
+    a:not(.btn) {
+      color: $link-color;
     }
   }
 

--- a/src/theme/_cms-ui.scss
+++ b/src/theme/_cms-ui.scss
@@ -109,8 +109,10 @@ body.cms-ui {
   }
 
   .public-ui {
-    a:not(.btn) {
-      color: $link-color;
+    :not(.it-header-wrapper) {
+      a:not(.btn) {
+        color: $link-color;
+      }
     }
   }
 


### PR DESCRIPTION
Header slim quando dentro al CMS, lato destro, cambiava colore

<img width="1710" alt="Schermata 2024-03-08 alle 16 50 36" src="https://github.com/italia/design-comuni-plone-theme/assets/60133113/662c808f-addc-48fc-8a32-692a51dab1ff">
<img width="1709" alt="Schermata 2024-03-08 alle 16 50 48" src="https://github.com/italia/design-comuni-plone-theme/assets/60133113/a57e08bf-df9b-44f5-93d4-b2c7947b7f11">
