### PR TITLE
chore: Update volto form block default validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "volto-dropdownmenu": "4.1.1",
     "volto-editablefooter": "5.1.0",
     "volto-feedback": "0.3.0",
-    "volto-form-block": "3.5.0",
+    "volto-form-block": "3.5.1",
     "volto-gdpr-privacy": "2.1.1",
     "volto-google-analytics": "2.0.0",
     "volto-multilingual-widget": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "volto-dropdownmenu": "4.1.1",
     "volto-editablefooter": "5.1.0",
     "volto-feedback": "0.3.0",
-    "volto-form-block": "3.5.1",
+    "volto-form-block": "3.5.2",
     "volto-gdpr-privacy": "2.1.1",
     "volto-google-analytics": "2.0.0",
     "volto-multilingual-widget": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "volto-dropdownmenu": "4.1.1",
     "volto-editablefooter": "5.1.0",
     "volto-feedback": "0.3.0",
-    "volto-form-block": "3.5.2",
+    "volto-form-block": "3.7.0",
     "volto-gdpr-privacy": "2.1.1",
     "volto-google-analytics": "2.0.0",
     "volto-multilingual-widget": "3.0.0",

--- a/src/customizations/volto-form-block/components/Edit.jsx
+++ b/src/customizations/volto-form-block/components/Edit.jsx
@@ -79,7 +79,13 @@ class Edit extends SubblocksEdit {
 
     return (
       <div className="public-ui">
-        <ValidateConfigForm data={this.props.data} onEdit={true}>
+        <ValidateConfigForm
+          data={this.props.data}
+          onEdit={true}
+          onChangeBlock={(data) => {
+            this.props.onChangeBlock(this.props.block, data);
+          }}
+        >
           <div className="px-4 py-5">
             {this.props?.data?.title && <h2>{this.props.data.title}</h2>}
             {this.props?.data?.description && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,7 +6576,7 @@ __metadata:
     volto-dropdownmenu: 4.1.1
     volto-editablefooter: 5.1.0
     volto-feedback: 0.3.0
-    volto-form-block: 3.5.1
+    volto-form-block: 3.5.2
     volto-gdpr-privacy: 2.1.1
     volto-google-analytics: 2.0.0
     volto-multilingual-widget: 3.0.0
@@ -14355,9 +14355,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-form-block@npm:3.5.1":
-  version: 3.5.1
-  resolution: "volto-form-block@npm:3.5.1"
+"volto-form-block@npm:3.5.2":
+  version: 3.5.2
+  resolution: "volto-form-block@npm:3.5.2"
   dependencies:
     "@hcaptcha/react-hcaptcha": ^0.3.6
     file-saver: ^2.0.5
@@ -14366,7 +14366,7 @@ __metadata:
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
     volto-subblocks: ^2.0.0
-  checksum: 9f04f0077fe517ce6ca2d3f7ad053c2a7f5d168c14834ebb4b15830111ae963bb82f254f92291c48b9dfa2cf06dc899f896e4d0fb53247b835af609a0474618d
+  checksum: 8154132d440df4cd6d240fb4b913607890ca9128fae7b9efc7d2037bf47fbe0007cab51cc009fca14793db5dc38b18432383e5b491d0d9aeb56ab89cf65942df
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,7 +6576,7 @@ __metadata:
     volto-dropdownmenu: 4.1.1
     volto-editablefooter: 5.1.0
     volto-feedback: 0.3.0
-    volto-form-block: 3.5.2
+    volto-form-block: 3.7.0
     volto-gdpr-privacy: 2.1.1
     volto-google-analytics: 2.0.0
     volto-multilingual-widget: 3.0.0
@@ -14355,9 +14355,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-form-block@npm:3.5.2":
-  version: 3.5.2
-  resolution: "volto-form-block@npm:3.5.2"
+"volto-form-block@npm:3.7.0":
+  version: 3.7.0
+  resolution: "volto-form-block@npm:3.7.0"
   dependencies:
     "@hcaptcha/react-hcaptcha": ^0.3.6
     file-saver: ^2.0.5
@@ -14366,7 +14366,7 @@ __metadata:
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
     volto-subblocks: ^2.0.0
-  checksum: 8154132d440df4cd6d240fb4b913607890ca9128fae7b9efc7d2037bf47fbe0007cab51cc009fca14793db5dc38b18432383e5b491d0d9aeb56ab89cf65942df
+  checksum: c2289a75f34027be1f8fb6f8a69628f9dfc4b773ed757cad83be7a0f42259e3efdac56d5c17dbaca98aff772abc6a1cff8edaef766fe395ad18270cb36f2cf98
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,7 +6576,7 @@ __metadata:
     volto-dropdownmenu: 4.1.1
     volto-editablefooter: 5.1.0
     volto-feedback: 0.3.0
-    volto-form-block: 3.5.0
+    volto-form-block: 3.5.1
     volto-gdpr-privacy: 2.1.1
     volto-google-analytics: 2.0.0
     volto-multilingual-widget: 3.0.0
@@ -14355,9 +14355,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-form-block@npm:3.5.0":
-  version: 3.5.0
-  resolution: "volto-form-block@npm:3.5.0"
+"volto-form-block@npm:3.5.1":
+  version: 3.5.1
+  resolution: "volto-form-block@npm:3.5.1"
   dependencies:
     "@hcaptcha/react-hcaptcha": ^0.3.6
     file-saver: ^2.0.5
@@ -14366,7 +14366,7 @@ __metadata:
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
     volto-subblocks: ^2.0.0
-  checksum: 9fc4b23423570af283495a9198be5b477014fd554d5cf11c588096b776439987d1b640f24625c7197e582549054aaca30d7d4fec089f3e8f720a13c15abb336c
+  checksum: 9f04f0077fe517ce6ca2d3f7ad053c2a7f5d168c14834ebb4b15830111ae963bb82f254f92291c48b9dfa2cf06dc899f896e4d0fb53247b835af609a0474618d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
aggiornato volto-form-block per avere:

- la validazione di default degli indirizzi email inseriti nei campi di configurazione della form 'Mittente di default' e 'Destinatari'
- rimosso il campo 'Obbligatorio' dal tipo di campo 'Testo statico' perchè inutile.