### PR TITLE
fix: multilingual home link per LanguageRootFolder

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,6 +47,10 @@
 
 - Ora il titolo, sottotitolo, favicon, logo e logo del footer sono editabili dal pannello di controllo del Sito. Se non impostati, verranno usati quelli definiti dagli sviluppatori.
 
+### Fix
+
+- Ripristinato il funzionamento del filtro luogo nella ricerca eventi.
+
 ## Versione 11.16.0 (10/07/2024)
 
 ### Migliorie

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
 -->
 
+## Versione x.x.x (dd/MM/yyyy)
+
+### Novità
+
+- Ora il titolo, sottotitolo, favicon, logo e logo del footer sono editabili dal pannello di controllo del Sito. Se non impostati, verranno usati quelli definiti dagli sviluppatori.
+
 ## Versione 11.16.0 (10/07/2024)
 
 ### Migliorie

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -3337,7 +3337,7 @@ msgid "search_startDate"
 msgstr ""
 
 #: helpers/Translations/searchBlockExtendedTranslations
-# defaultMessage: Ricerca per: <em>{searchedtext}</em>. 
+# defaultMessage: Ricerca per: <em>{searchedtext}</em>.
 msgid "searchedFor"
 msgstr ""
 

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-06-25T15:14:34.369Z\n"
+"POT-Creation-Date: 2024-07-15T11:07:19.251Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -3337,7 +3337,7 @@ msgid "search_startDate"
 msgstr ""
 
 #: helpers/Translations/searchBlockExtendedTranslations
-# defaultMessage: Ricerca per: <em>{searchedtext}</em>.
+# defaultMessage: Ricerca per: <em>{searchedtext}</em>. 
 msgid "searchedFor"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "volto-querywidget-with-browser",
     "@eeacms/volto-taxonomy",
     "volto-feedback",
-    "volto-slimheader"
+    "volto-slimheader",
+    "volto-site-settings"
   ],
   "scripts": {
     "prepare": "husky install",
@@ -158,11 +159,12 @@
     "volto-querywidget-with-browser": "0.4.2",
     "volto-rss-block": "3.0.0",
     "volto-secondarymenu": "4.1.1",
+    "volto-site-settings": "0.4.3",
     "volto-slimheader": "0.1.2",
     "volto-social-settings": "3.0.0",
     "volto-subblocks": "2.1.0",
     "volto-subfooter": "3.1.1",
-    "volto-subsites": "4.0.1",
+    "volto-subsites": "4.0.2",
     "volto-venue": "4.1.0",
     "webpack-image-resize-loader": "^5.0.0"
   },

--- a/src/components/ItaliaTheme/AppExtras/GenericAppExtras.jsx
+++ b/src/components/ItaliaTheme/AppExtras/GenericAppExtras.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
-import { Helmet, BodyClass } from '@plone/volto/helpers';
+import { BodyClass } from '@plone/volto/helpers';
 import { RemoveBodyClass } from 'design-comuni-plone-theme/components/ItaliaTheme';
-import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 import ScrollToTop from 'design-comuni-plone-theme/components/ItaliaTheme/ScrollToTop/ScrollToTop';
 import { SubsiteLoader } from 'volto-subsites';
 import config from '@plone/volto/registry';
 
 const GenericAppExtras = (props) => {
-  const intl = useIntl();
   const location = useLocation();
 
   const subsite = useSelector((state) => state.subsite?.data);
@@ -19,7 +16,6 @@ const GenericAppExtras = (props) => {
   if (subsiteLoadable) {
     subsiteLoadable.load();
   }
-  const siteTitle = subsite?.title ?? getSiteProperty('siteTitle', intl.locale);
 
   const FORCE_PUBLIC_UI = ['/sitemap', '/search'];
   const isPublicUI = FORCE_PUBLIC_UI.reduce(
@@ -29,7 +25,6 @@ const GenericAppExtras = (props) => {
 
   return (
     <>
-      <Helmet titleTemplate={`%s - ${siteTitle}`} />
       {isPublicUI && (
         <>
           <BodyClass className="public-ui" />

--- a/src/components/ItaliaTheme/AppExtras/SiteSettingsExtras.jsx
+++ b/src/components/ItaliaTheme/AppExtras/SiteSettingsExtras.jsx
@@ -1,0 +1,35 @@
+/*
+CUSTOMIZATIONS:
+- get defaultValue from siteProperties
+*/
+
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { Helmet } from '@plone/volto/helpers';
+import { SiteProperty } from 'volto-site-settings';
+import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
+
+const SiteSettingsExtras = (props) => {
+  const intl = useIntl();
+  let siteTitle = SiteProperty({
+    property: 'site_title',
+    getValue: true,
+    defaultValue: getSiteProperty('siteTitle', intl.locale),
+  });
+
+  const parentSiteTitle = SiteProperty({
+    property: 'site_title',
+    getValue: true,
+    getParent: true,
+    defaultValue: getSiteProperty('parentSiteTitle', intl.locale),
+  });
+
+  if (parentSiteTitle !== siteTitle) {
+    siteTitle = siteTitle + ' - ' + parentSiteTitle;
+  }
+
+  siteTitle = siteTitle.replaceAll('\\n', ' - ');
+
+  return <Helmet titleTemplate={`%s - ${siteTitle}`} />;
+};
+export default SiteSettingsExtras;

--- a/src/components/ItaliaTheme/Blocks/EventSearch/DefaultFilters.js
+++ b/src/components/ItaliaTheme/Blocks/EventSearch/DefaultFilters.js
@@ -36,6 +36,8 @@ const DefaultFilters = () => {
   const intl = useIntl();
   moment.locale(intl.locale);
   const subsite = useSelector((state) => state.subsite?.data);
+  const isSubsiteValid = subsite && Object.keys(subsite).length > 0;
+  const path = isSubsiteValid ? flattenToAppURL(subsite['@id']) : '/';
 
   return {
     text_filter: {
@@ -68,7 +70,7 @@ const DefaultFilters = () => {
           isSearchable: true,
           options: {
             dispatch: {
-              path: subsite ? flattenToAppURL(subsite['@id']) : '/',
+              path: path,
               portal_types: ['Venue'],
               fullobjects: 0,
               b_size: 10000,

--- a/src/components/ItaliaTheme/BrandText/BrandText.jsx
+++ b/src/components/ItaliaTheme/BrandText/BrandText.jsx
@@ -4,21 +4,31 @@ import { useIntl } from 'react-intl';
 import { SiteProperty } from 'volto-site-settings';
 import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 
-const BrandText = ({ mobile = false, getParent = false }) => {
+const BrandText = ({ mobile = false, subsite, getParent = false }) => {
   const intl = useIntl();
-  let title = SiteProperty({
-    property: 'site_title',
-    defaultValue: getSiteProperty('siteTitle', intl.locale),
-    getValue: true,
-    getParent: getParent,
-  });
+  // TODO DEPRECATED: remove and only use SiteProperty
+  const deprecatedSiteTitle =
+    subsite?.title || getSiteProperty('siteTitle', intl.locale);
+  let title =
+    deprecatedSiteTitle ||
+    SiteProperty({
+      property: 'site_title',
+      defaultValue: getSiteProperty('siteTitle', intl.locale),
+      getValue: true,
+      getParent: getParent,
+    });
 
-  const description = SiteProperty({
-    property: 'site_subtitle',
-    defaultValue: getSiteProperty('siteSubtitle', intl.locale),
-    getValue: true,
-    getParent: getParent,
-  });
+  // TODO DEPRECATED: remove and only use SiteProperty
+  const deprecatedSiteSubtitle =
+    subsite?.description || getSiteProperty('siteSubtitle', intl.locale);
+  const description =
+    deprecatedSiteSubtitle ||
+    SiteProperty({
+      property: 'site_subtitle',
+      defaultValue: getSiteProperty('siteSubtitle', intl.locale),
+      getValue: true,
+      getParent: getParent,
+    });
   const titleSplit = title?.split('\n') ?? null;
   title = titleSplit?.map((t, i) => (
     <>
@@ -29,13 +39,11 @@ const BrandText = ({ mobile = false, getParent = false }) => {
 
   return (
     <div className="it-brand-text">
-      {title && <div className="it-brand-title">{title}</div>}
+      {title && <p className="no_toc h2">{title}</p>}
       {description && (
-        <div
-          className={cx('it-brand-tagline', { 'd-none d-md-block': !mobile })}
-        >
+        <p className={cx('no_toc h3', { 'd-none d-md-block': !mobile })}>
           {description}
-        </div>
+        </p>
       )}
     </div>
   );

--- a/src/components/ItaliaTheme/BrandText/BrandText.jsx
+++ b/src/components/ItaliaTheme/BrandText/BrandText.jsx
@@ -1,18 +1,42 @@
 import React from 'react';
 import cx from 'classnames';
 import { useIntl } from 'react-intl';
+import { SiteProperty } from 'volto-site-settings';
 import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 
-const BrandText = ({ mobile = false, subsite }) => {
+const BrandText = ({ mobile = false, getParent = false }) => {
   const intl = useIntl();
+  let title = SiteProperty({
+    property: 'site_title',
+    defaultValue: getSiteProperty('siteTitle', intl.locale),
+    getValue: true,
+    getParent: getParent,
+  });
+
+  const description = SiteProperty({
+    property: 'site_subtitle',
+    defaultValue: getSiteProperty('siteSubtitle', intl.locale),
+    getValue: true,
+    getParent: getParent,
+  });
+  const titleSplit = title?.split('\n') ?? null;
+  title = titleSplit?.map((t, i) => (
+    <>
+      {t}
+      {i < titleSplit.length - 1 && <br />}
+    </>
+  ));
+
   return (
     <div className="it-brand-text">
-      <p className="no_toc h2">
-        {subsite?.title || getSiteProperty('siteTitle', intl.locale)}
-      </p>
-      <p className={cx('no_toc h3', { 'd-none d-md-block': !mobile })}>
-        {subsite?.description || getSiteProperty('siteSubtitle', intl.locale)}
-      </p>
+      {title && <div className="it-brand-title">{title}</div>}
+      {description && (
+        <div
+          className={cx('it-brand-tagline', { 'd-none d-md-block': !mobile })}
+        >
+          {description}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/ItaliaTheme/BrandTextFooter/BrandTextFooter.jsx
+++ b/src/components/ItaliaTheme/BrandTextFooter/BrandTextFooter.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BrandText } from 'design-comuni-plone-theme/components/ItaliaTheme';
 
 const BrandTextFooter = () => {
-  return <BrandText />;
+  return <BrandText getParent={true} />;
 };
 
 export default BrandTextFooter;

--- a/src/components/ItaliaTheme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/ItaliaTheme/Breadcrumbs/Breadcrumbs.jsx
@@ -21,6 +21,7 @@ import {
 import { UniversalLink } from '@plone/volto/components';
 import { Row, Col, BreadcrumbItem } from 'design-react-kit';
 import GoogleBreadcrumbs from 'design-comuni-plone-theme/components/ItaliaTheme/Breadcrumbs/GoogleBreadcrumbs';
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
 import config from '@plone/volto/registry';
 
 const messages = defineMessages({
@@ -98,6 +99,7 @@ const Breadcrumbs = ({ pathname }) => {
       items = [];
     }
   }
+  const homepath = useHomePath();
 
   return items?.length > 0 ? (
     <>
@@ -110,7 +112,7 @@ const Breadcrumbs = ({ pathname }) => {
           >
             <ol className="breadcrumb" data-element="breadcrumb">
               <BreadcrumbItem tag="li">
-                <UniversalLink href="/">
+                <UniversalLink href={homepath}>
                   {intl.formatMessage(messages.home)}
                 </UniversalLink>
                 <span className="separator">/</span>

--- a/src/components/ItaliaTheme/Footer/FooterInfos.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterInfos.jsx
@@ -17,6 +17,8 @@ import {
   FooterSocials,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
 
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
+
 const messages = defineMessages({
   goToPage: {
     id: 'Vai alla pagina',
@@ -29,7 +31,7 @@ const FooterInfos = () => {
   const N_COLUMNS = 4;
   const location = useLocation();
   const dispatch = useDispatch();
-
+  const homepath = useHomePath();
   const footerConfiguration = useSelector(
     (state) => state.editableFooterColumns?.result,
   );
@@ -41,7 +43,7 @@ const FooterInfos = () => {
   //filter rootpaths
   const footerColumns = getItemsByPath(
     footerConfiguration,
-    location?.pathname?.length ? location.pathname : '/',
+    location?.pathname?.length ? location.pathname : homepath,
   );
 
   const colWidth =

--- a/src/components/ItaliaTheme/Footer/FooterMain.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterMain.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { Container, Row, Col } from 'design-react-kit';
 
 import { UniversalLink } from '@plone/volto/components';
+import { FooterTop } from 'volto-editablefooter';
 import {
   FooterNavigation,
   FooterInfos,
@@ -14,8 +15,7 @@ import {
   BrandTextFooter,
   FooterPNRRLogo,
 } from 'design-comuni-plone-theme/components/ItaliaTheme/';
-
-import { FooterTop } from 'volto-editablefooter';
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
 
 /**
  * FooterMain component class.
@@ -24,7 +24,7 @@ import { FooterTop } from 'volto-editablefooter';
  */
 const FooterMain = () => {
   const footerTopContent = FooterTop();
-
+  const homepath = useHomePath();
   return (
     <div className="it-footer-main">
       <Container tag="div">
@@ -35,7 +35,7 @@ const FooterMain = () => {
                 {footerTopContent ?? (
                   <>
                     <FooterPNRRLogo />
-                    <UniversalLink href="/">
+                    <UniversalLink href={homepath}>
                       <LogoFooter />
                       <BrandTextFooter />
                     </UniversalLink>

--- a/src/components/ItaliaTheme/Footer/FooterSmall.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterSmall.jsx
@@ -5,15 +5,18 @@
 
 import React, { useEffect } from 'react';
 import cx from 'classnames';
-import { UniversalLink } from '@plone/volto/components';
 import { defineMessages, useIntl } from 'react-intl';
 import { Container } from 'design-react-kit';
-import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 import { useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { getSubFooter, getItemsByPath } from 'volto-subfooter';
-import { flattenToAppURL } from '@plone/volto/helpers';
 import { displayBanner } from 'volto-gdpr-privacy';
+import { UniversalLink } from '@plone/volto/components';
+import { flattenToAppURL } from '@plone/volto/helpers';
+import {
+  getSiteProperty,
+  useHomePath,
+} from 'design-comuni-plone-theme/helpers';
 
 const messages = defineMessages({
   goToPage: {
@@ -35,7 +38,7 @@ const FooterSmall = () => {
   const intl = useIntl();
   const pathname = useLocation().pathname;
   const dispatch = useDispatch();
-
+  const homepath = useHomePath();
   const subFooter = useSelector((state) => state.subFooter?.result);
   const subFooterItems = getItemsByPath(subFooter, pathname)?.filter(
     (item) => item.visible,
@@ -54,7 +57,9 @@ const FooterSmall = () => {
           {subFooterItems?.length > 0 &&
             subFooterItems.map((item, index) => {
               let url =
-                item.href || flattenToAppURL(item.linkUrl?.[0]?.['@id']) || '/';
+                item.href ||
+                flattenToAppURL(item.linkUrl?.[0]?.['@id']) ||
+                homepath;
               return (
                 <li
                   className={cx('list-inline-item', {

--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -30,14 +30,6 @@ const messages = defineMessages({
 const HeaderCenter = () => {
   const intl = useIntl();
   const subsite = useSelector((state) => state.subsite?.data);
-  const logoSubsite = subsite?.subsite_logo && (
-    <figure className="icon">
-      <img
-        src={flattenToAppURL(subsite.subsite_logo.scales?.mini?.download)}
-        alt={intl.formatMessage(messages.logoSubsiteAlt)}
-      />
-    </figure>
-  );
 
   return (
     <Header small={false} theme="" type="center">
@@ -47,7 +39,9 @@ const HeaderCenter = () => {
             href={subsite?.['@id'] ? flattenToAppURL(subsite['@id']) : '/'}
             title={intl.formatMessage(messages.subsiteUniversalLink)}
           >
-            {subsite?.subsite_logo ? logoSubsite : <Logo />}
+            <Logo
+              alt={subsite ? intl.formatMessage(messages.logoSubsiteAlt) : null}
+            />
             <BrandText subsite={subsite} />
           </UniversalLink>
         </div>

--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -30,6 +30,11 @@ const messages = defineMessages({
 const HeaderCenter = () => {
   const intl = useIntl();
   const subsite = useSelector((state) => state.subsite?.data);
+  const logoSubsite = subsite?.subsite_logo && (
+    <figure className="icon">
+      <Logo alt={intl.formatMessage(messages.logoSubsiteAlt)} />
+    </figure>
+  );
 
   return (
     <Header small={false} theme="" type="center">
@@ -39,9 +44,7 @@ const HeaderCenter = () => {
             href={subsite?.['@id'] ? flattenToAppURL(subsite['@id']) : '/'}
             title={intl.formatMessage(messages.subsiteUniversalLink)}
           >
-            <Logo
-              alt={subsite ? intl.formatMessage(messages.logoSubsiteAlt) : null}
-            />
+            {subsite?.subsite_logo ? logoSubsite : <Logo className="icon" />}
             <BrandText subsite={subsite} />
           </UniversalLink>
         </div>

--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -15,6 +15,7 @@ import {
   HeaderSearch,
   BrandText,
 } from 'design-comuni-plone-theme/components/ItaliaTheme';
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
 
 const messages = defineMessages({
   logoSubsiteAlt: {
@@ -35,13 +36,14 @@ const HeaderCenter = () => {
       <Logo alt={intl.formatMessage(messages.logoSubsiteAlt)} />
     </figure>
   );
+  const homepath = useHomePath();
 
   return (
     <Header small={false} theme="" type="center">
       <HeaderContent>
         <div className="it-brand-wrapper ps-4">
           <UniversalLink
-            href={subsite?.['@id'] ? flattenToAppURL(subsite['@id']) : '/'}
+            href={subsite?.['@id'] ? flattenToAppURL(subsite['@id']) : homepath}
             title={intl.formatMessage(messages.subsiteUniversalLink)}
           >
             {subsite?.subsite_logo ? logoSubsite : <Logo className="icon" />}

--- a/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
@@ -13,15 +13,18 @@ import {
   HeaderRightZone,
 } from 'design-react-kit';
 import { useIntl } from 'react-intl';
-import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
+import {
+  getSiteProperty,
+  useHomePath,
+} from 'design-comuni-plone-theme/helpers';
 import { SiteProperty } from 'volto-site-settings';
 
 const HeaderSlim = () => {
   const subsite = useSelector((state) => state.subsite?.data);
   const intl = useIntl();
-
+  const homepath = useHomePath();
   const parentSiteURL = subsite
-    ? '/'
+    ? homepath
     : getSiteProperty('parentSiteURL', intl.locale);
 
   const staticParentSiteTitle = getSiteProperty('parentSiteTitle', intl.locale);

--- a/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
@@ -14,6 +14,7 @@ import {
 } from 'design-react-kit';
 import { useIntl } from 'react-intl';
 import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
+import { SiteProperty } from 'volto-site-settings';
 
 const HeaderSlim = () => {
   const subsite = useSelector((state) => state.subsite?.data);
@@ -23,9 +24,15 @@ const HeaderSlim = () => {
     ? '/'
     : getSiteProperty('parentSiteURL', intl.locale);
 
-  const parentSiteTile = subsite
-    ? getSiteProperty('subsiteParentSiteTitle', intl.locale)
-    : getSiteProperty('parentSiteTitle', intl.locale);
+  const staticParentSiteTitle = getSiteProperty('parentSiteTitle', intl.locale);
+
+  const parentSiteTile = SiteProperty({
+    property: 'site_title',
+    forceValue: subsite ? null : staticParentSiteTitle,
+    defaultValue: staticParentSiteTitle,
+    getValue: true,
+    getParent: true,
+  });
 
   const target = subsite ? null : '_blank';
   return (
@@ -37,7 +44,7 @@ const HeaderSlim = () => {
           target={target}
           rel="noopener noreferrer"
         >
-          {parentSiteTile}
+          {parentSiteTile.replaceAll('\\n', ' - ')}
         </HeaderBrand>
         <HeaderRightZone>
           <HeaderSlimRightZone />

--- a/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim/HeaderSlim.jsx
@@ -26,13 +26,20 @@ const HeaderSlim = () => {
 
   const staticParentSiteTitle = getSiteProperty('parentSiteTitle', intl.locale);
 
-  const parentSiteTile = SiteProperty({
-    property: 'site_title',
-    forceValue: subsite ? null : staticParentSiteTitle,
-    defaultValue: staticParentSiteTitle,
-    getValue: true,
-    getParent: true,
-  });
+  // TODO DEPRECATED use only SiteProperty
+  const deprecatedSubsiteParentSiteTitle = getSiteProperty(
+    'subsiteParentSiteTitle',
+    intl.locale,
+  );
+
+  const parentSiteTitle =
+    deprecatedSubsiteParentSiteTitle ||
+    SiteProperty({
+      property: 'site_title',
+      defaultValue: getSiteProperty('subsiteParentSiteTitle', intl.locale),
+      getValue: true,
+      getParent: true,
+    });
 
   const target = subsite ? null : '_blank';
   return (
@@ -44,7 +51,8 @@ const HeaderSlim = () => {
           target={target}
           rel="noopener noreferrer"
         >
-          {parentSiteTile.replaceAll('\\n', ' - ')}
+          {!subsite && staticParentSiteTitle}
+          {subsite && parentSiteTitle.replaceAll('\\n', ' - ')}
         </HeaderBrand>
         <HeaderRightZone>
           <HeaderSlimRightZone />

--- a/src/components/ItaliaTheme/Header/ParentSiteMenu.jsx
+++ b/src/components/ItaliaTheme/Header/ParentSiteMenu.jsx
@@ -8,12 +8,14 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { Nav, NavItem, NavLink } from 'design-react-kit';
+import { useHomePath } from 'design-comuni-plone-theme/helpers';
 
 const ParentSiteMenu = () => {
   const dropdownMenu = useSelector(
     (state) => state.dropdownMenuNavItems?.result,
   );
   const subsite = useSelector((state) => state.subsite?.data);
+  const homepath = useHomePath();
 
   let menu = null;
   if (subsite) {
@@ -23,7 +25,7 @@ const ParentSiteMenu = () => {
     let i = url_split.length - 1;
     while (i > 0) {
       let s = url_split.slice(0, i).join('/');
-      s = s.length === 0 ? '/' : s;
+      s = s.length === 0 ? homepath : s;
       // eslint-disable-next-line no-loop-func
       dropdownMenu.forEach((m) => {
         if (m.rootPath === s) {

--- a/src/components/ItaliaTheme/Logo/Logo.jsx
+++ b/src/components/ItaliaTheme/Logo/Logo.jsx
@@ -23,12 +23,12 @@
 import logo from './logo.png';
 import { SiteProperty } from 'volto-site-settings';
 
-const Logo = ({ alt = 'Logo' }) => {
+const Logo = ({ alt = 'Logo', className }) => {
   return (
     <SiteProperty
       property="site_logo"
       defaultValue={{ url: logo, width: 82, height: 82 }}
-      className="icon"
+      className={className}
       alt={alt}
     />
   );

--- a/src/components/ItaliaTheme/Logo/Logo.jsx
+++ b/src/components/ItaliaTheme/Logo/Logo.jsx
@@ -10,9 +10,10 @@
  * Note the icon class.
  */
 
-/* SVG example */
-// import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
-// const Logo = () => <Icon color="" icon="it-pa" padding={false} size="" />;
+/* SVG example
+ import { Icon } from 'design-comuni-plone-theme/components/ItaliaTheme';
+ const Logo = () => <Icon color="" icon="it-pa" padding={false} size="" />;
+*/
 
 /* PNG example using https://www.npmjs.com/package/webpack-image-resize-loader *
  * works, but some issues with prettier and jest
@@ -20,9 +21,16 @@
 // eslint-disable-next-line import/no-unresolved
 //import logo from './logo.png?width=164';
 import logo from './logo.png';
+import { SiteProperty } from 'volto-site-settings';
 
-const Logo = () => (
-  <img className="icon" src={logo} width="82" height="82" alt="Logo" />
-);
-
+const Logo = ({ alt = 'Logo' }) => {
+  return (
+    <SiteProperty
+      property="site_logo"
+      defaultValue={{ url: logo, width: 82, height: 82 }}
+      className="icon"
+      alt={alt}
+    />
+  );
+};
 export default Logo;

--- a/src/components/ItaliaTheme/LogoFooter/LogoFooter.jsx
+++ b/src/components/ItaliaTheme/LogoFooter/LogoFooter.jsx
@@ -12,9 +12,17 @@
 
 // eslint-disable-next-line import/no-unresolved
 import logo from '../Logo/logo.png';
+import { SiteProperty } from 'volto-site-settings';
 
-const LogoFooter = () => (
-  <img className="icon" src={logo} width="82" height="82" alt="Logo" />
-);
+const LogoFooter = () => {
+  return (
+    <SiteProperty
+      property="site_logo_footer"
+      defaultValue={{ url: logo, width: 82, height: 82 }}
+      className="icon"
+      alt="Logo"
+    />
+  );
+};
 
 export default LogoFooter;

--- a/src/components/ItaliaTheme/View/ServizioView/ServizioMetatag.jsx
+++ b/src/components/ItaliaTheme/View/ServizioView/ServizioMetatag.jsx
@@ -16,11 +16,15 @@ const fieldDataToPlainText = (field) => {
 
 const ServizioMetatag = ({ content }) => {
   const intl = useIntl();
-  let siteTitle = SiteProperty({
-    property: 'site_title',
-    getValue: true,
-    defaultTitle: getSiteProperty('siteTitle', intl.locale),
-  });
+  // TODO DEPRECATED use only SiteProperty
+  const deprecatedSiteTitle = getSiteProperty('siteTitle', intl.locale);
+  let siteTitle =
+    deprecatedSiteTitle ||
+    SiteProperty({
+      property: 'site_title',
+      getValue: true,
+      defaultTitle: getSiteProperty('siteTitle', intl.locale),
+    });
   siteTitle = siteTitle.replaceAll('\\n', ' - ');
 
   const schemaOrg = {

--- a/src/components/ItaliaTheme/View/ServizioView/ServizioMetatag.jsx
+++ b/src/components/ItaliaTheme/View/ServizioView/ServizioMetatag.jsx
@@ -1,4 +1,6 @@
+import { useIntl } from 'react-intl';
 import { Helmet, toPublicURL, isInternalURL } from '@plone/volto/helpers';
+import { SiteProperty } from 'volto-site-settings';
 import { getSiteProperty } from 'design-comuni-plone-theme/helpers';
 import { richTextHasContent } from 'design-comuni-plone-theme/components/ItaliaTheme/View';
 
@@ -13,7 +15,13 @@ const fieldDataToPlainText = (field) => {
 };
 
 const ServizioMetatag = ({ content }) => {
-  const siteTitle = getSiteProperty('siteTitle');
+  const intl = useIntl();
+  let siteTitle = SiteProperty({
+    property: 'site_title',
+    getValue: true,
+    defaultTitle: getSiteProperty('siteTitle', intl.locale),
+  });
+  siteTitle = siteTitle.replaceAll('\\n', ' - ');
 
   const schemaOrg = {
     '@context': 'https://schema.org',

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -35,6 +35,8 @@ import GenericAppExtras from 'design-comuni-plone-theme/components/ItaliaTheme/A
 import PageLoader from 'design-comuni-plone-theme/components/ItaliaTheme/AppExtras/PageLoader';
 import TrackFocus from 'design-comuni-plone-theme/components/ItaliaTheme/AppExtras/TrackFocus';
 import redraft from 'redraft';
+
+import SiteSettingsExtras from 'design-comuni-plone-theme/components/ItaliaTheme/AppExtras/SiteSettingsExtras';
 import { loadables as ItaliaLoadables } from 'design-comuni-plone-theme/config/loadables';
 
 // CTs icons
@@ -298,6 +300,10 @@ export default function applyConfig(voltoConfig) {
         match: '',
         component: TrackFocus,
       },
+      {
+        match: '',
+        component: SiteSettingsExtras,
+      },
     ],
     maxFileUploadSize: null,
     'volto-blocks-widget': {
@@ -518,6 +524,10 @@ export default function applyConfig(voltoConfig) {
     ...config.components,
     BlockExtraTags: { component: () => null },
   };
+  config.registerComponent({
+    name: 'SiteSettingsExtras',
+    component: SiteSettingsExtras,
+  });
 
   // REDUCERS
   config.addonReducers = {

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -38,10 +38,7 @@ const Navigation = ({ pathname }) => {
   const subsite = useSelector((state) => state.subsite?.data);
   const logoSubsite = subsite?.subsite_logo && (
     <figure className="icon">
-      <img
-        src={flattenToAppURL(subsite.subsite_logo.scales?.mini?.download)}
-        alt="Logo"
-      />
+      <Logo />
     </figure>
   );
 
@@ -136,7 +133,11 @@ const Navigation = ({ pathname }) => {
                     }
                     onClick={() => setCollapseOpen(false)}
                   >
-                    {subsite?.subsite_logo ? logoSubsite : <Logo />}
+                    {subsite?.subsite_logo ? (
+                      logoSubsite
+                    ) : (
+                      <Logo className="icon" />
+                    )}
                     <BrandText mobile={true} subsite={subsite} />
                   </UniversalLink>
                 </div>

--- a/src/customizations/volto/helpers/Html/Html.jsx
+++ b/src/customizations/volto/helpers/Html/Html.jsx
@@ -4,7 +4,7 @@
  */
 /*
  CUSTOMIZATIONS:
- - Add <link rel="shortcut icon" href="/favicon.ico" />
+ - Rimosso <link rel="shortcut icon" href="/favicon.ico" /> perchè creato da volto-site-settings
  - Add shrink-to-fit=no in viewport meta
  - Remove link for manifest and svg/apple icons
  */
@@ -122,7 +122,7 @@ class Html extends Component {
               })};`,
             }}
           />
-          <link rel="shortcut icon" href="/favicon.ico" />
+          {/* <link rel="shortcut icon" href="/favicon.ico" /> */}
           <meta property="og:type" content="website" />
           <meta name="generator" content="Plone 6 - https://plone.org" />
           <meta

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -52,3 +52,4 @@ export {
 export { commonSearchBlockMessages } from 'design-comuni-plone-theme/helpers/Translations/searchBlockExtendedTranslations';
 
 export { getComponentWithFallback } from 'design-comuni-plone-theme/helpers/registry';
+export { useHomePath } from 'design-comuni-plone-theme/helpers/url';

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+import config from '@plone/volto/registry';
+import { useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+export const useHomePath = () => {
+  const [path, setPath] = useState('/');
+
+  const locale = useSelector((state) => state.intl.locale);
+  //const { pathname } = useLocation();
+
+  useEffect(() => {
+    setPath(config.settings.isMultilingual ? '/' + locale : '/');
+  }, [locale]);
+  return path;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8223,11 +8223,12 @@ __metadata:
     volto-querywidget-with-browser: 0.4.2
     volto-rss-block: 3.0.0
     volto-secondarymenu: 4.1.1
+    volto-site-settings: 0.4.3
     volto-slimheader: 0.1.2
     volto-social-settings: 3.0.0
     volto-subblocks: 2.1.0
     volto-subfooter: 3.1.1
-    volto-subsites: 4.0.1
+    volto-subsites: 4.0.2
     volto-venue: 4.1.0
     webpack-image-resize-loader: ^5.0.0
   peerDependencies:
@@ -16207,6 +16208,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"volto-site-settings@npm:0.4.3":
+  version: 0.4.3
+  resolution: "volto-site-settings@npm:0.4.3"
+  dependencies:
+    volto-multilingual-widget: 3.2.1
+  peerDependencies:
+    "@plone/volto": ^17.0.0
+  checksum: 690d1c03a0b45955f99c98de119ac35038cea9970aa23ed6467e5bf240baca732a704fc4c2d1a6e5f3e916fb3bcd599d7303db989a78fdc07e198ed072d19350
+  languageName: node
+  linkType: hard
+
 "volto-slimheader@npm:0.1.2":
   version: 0.1.2
   resolution: "volto-slimheader@npm:0.1.2"
@@ -16246,12 +16258,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"volto-subsites@npm:4.0.1":
-  version: 4.0.1
-  resolution: "volto-subsites@npm:4.0.1"
+"volto-subsites@npm:4.0.2":
+  version: 4.0.2
+  resolution: "volto-subsites@npm:4.0.2"
   peerDependencies:
     "@plone/volto": ">=16.0.0-alpha.38"
-  checksum: 0796a9f77c2a4666898ecc6d23af3d7c15afe9053a6ea2f690db0cb93082327143225f02620591033b335b94f0fa7f78fed458157cdb1142cf47739e5678b8ae
+  checksum: 77408b4ea19f9ca4d659544b2ddc87fb0a62e64eeba3a6fa6a3e9acd62b1f23fe5a31c0d483d2486016fdbe88e153b835150cc85318f06e0a4f113d8ac934b42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
è stato sistemato il link alla home page nel caso di siti multilingua. 
Prima puntava sempre a '/' e poi in automatico veniva fatta la redirect alla radice di lingua. 
Ora i link alla homepage puntano alla radice della lingua corrente. 