### PR TITLE
vista news su ct ComunicatoStampa

### DIFF
--- a/src/config/Views/views.js
+++ b/src/config/Views/views.js
@@ -44,6 +44,7 @@ defineMessages({
 const italiaContentTypesViews = {
   Document: PageView,
   'News Item': NewsItemView,
+  ComunicatoStampa: NewsItemView, // ct opzionale da volto-rer-ufficiostampa
   UnitaOrganizzativa: UOView,
   Persona: PersonaView,
   Venue: VenueView,


### PR DESCRIPTION
questa changes non ha nessun effetto diretto sul prodotto, è quindi safe dal mio punto di vista portarla avanti.

ma se presente un prodotto per i comunicatistampa (WIP rer.ufficiostampa/volto-rer-ufficiostampa) usa la vista Notizia per quel CT.