### PR TITLE
fix: cambiato colore del font per il pulsante creato con draftJS

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Colore del font del bottone DraftJS nell'editor sistemato a bianco.
+
 ## Versione 11.25.1 (28/11/2024)
 
 ### Fix

--- a/src/theme/ItaliaTheme/_main.scss
+++ b/src/theme/ItaliaTheme/_main.scss
@@ -151,6 +151,9 @@ iframe {
         color: $primary-text;
         font-weight: 700;
       }
+      &.link-anchorlink-theme {
+        color: #fff !important;
+      }
     }
     /*
       Safari rendering issue workaround - B#60364


### PR DESCRIPTION
Colore del font di un bottone creato con DrattJS dentro un editor di testo era uguale al colore d'sfondo. Cambiato a bianco